### PR TITLE
Added missing multipath value to reset function

### DIFF
--- a/src/iperf.h
+++ b/src/iperf.h
@@ -170,6 +170,7 @@ struct iperf_settings
     int       idle_timeout;         /* server idle time timeout */
     struct iperf_time rcv_timeout;  /* Timeout for receiving messages in active mode, in us */
     int       multipath;            /* Enable multipath support (DCCP) */
+    int       fastclose;
 };
 
 struct iperf_test;

--- a/src/iperf_api.c
+++ b/src/iperf_api.c
@@ -3108,6 +3108,7 @@ iperf_reset_test(struct iperf_test *test)
     test->settings->mss = 0;
     test->settings->tos = 0;
     test->settings->dont_fragment = 0;
+    test->settings->multipath = 0;
     test->zerocopy = 0;
 
 #if defined(HAVE_SSL)

--- a/src/iperf_api.h
+++ b/src/iperf_api.h
@@ -93,6 +93,7 @@ typedef uint64_t iperf_size_t;
 #define OPT_RCV_TIMEOUT 27
 #define OPT_DCCP 28
 #define OPT_MULTIPATH 29
+#define OPT_FAST_CLOSE 30
 
 /* states */
 #define TEST_START 1

--- a/src/iperf_dccp.c
+++ b/src/iperf_dccp.c
@@ -459,6 +459,9 @@ iperf_dccp_connect(struct iperf_test *test)
         return -1;
     }
 
+    if ((opt = test->settings->fastclose))
+        setsockopt(s, SOL_DCCP, 23, &opt, sizeof(opt));
+
     freeaddrinfo(server_res);
     return s;
 #else

--- a/src/iperf_locale.c
+++ b/src/iperf_locale.c
@@ -152,6 +152,7 @@ const char usage_longstr[] = "Usage: iperf3 [-s|-c host] [options]\n"
 #if defined(HAVE_DCCP_H)
                            "  --dccp                    use DCCP protocol\n"
                            "  --multipath               enable multipath for DCCP\n"
+                           "  --fastclose               enable fastclose for MP-DCCP\n"
 #endif /* HAVE_DCCP_H */
                            "  -u, --udp                 use UDP rather than TCP\n"
                            "  --connect-timeout #       timeout for control connection setup (ms)\n"


### PR DESCRIPTION
Currently, there is a bug where after one test with the multipath flag set, every test afterward will also be a multipath test.
This fixes it.